### PR TITLE
Updated travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 sudo: false
+go_import_path: github.com/akamai-open/AkamaiOPEN-edgegrid-golang
 go:
   - 1.6
   - 1.7
@@ -16,9 +17,7 @@ addons:
     packages:
       - glide
 install:
-  - glide install
-  - cd edgegrid/json && go install . && cd ../ && go install .
+  - glide up
 script:
   - export PATH="$PATH:$HOME/gopath/bin"
-  - cp $HOME/gopath/src/github.com/akamai-open/AkamaiOPEN-edgegrid-golang/sample_edgerc $HOME/.edgerc
-  - go test -v ./
+  - cd edgegrid && go test -v -race ./...

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 98f2481dc812064a88e3d2386f54b0c630319d84897998ce4d02c304af980736
-updated: 2017-04-12T09:38:06.795149467-07:00
+hash: e0ce802d8b3e6d29f60003d6d352ad583e644e873be83ec76942854088b23291
+updated: 2017-04-21T19:08:49.367247804+01:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
@@ -13,6 +13,8 @@ imports:
   - difflib
 - name: github.com/Sirupsen/logrus
   version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 59fc8e570cd707a33a93842b00a9aae4b5cd38b2
   subpackages:
@@ -29,6 +31,10 @@ imports:
   version: 9d4e42a20653790449273b3c85e67d6d8bae6e2e
   subpackages:
   - unix
+- name: gopkg.in/airbrake/gobrake.v2
+  version: 3e9a4999b0371bf26c63fda81cc849383919b3da
+- name: gopkg.in/gemnasium/logrus-airbrake-hook.v2
+  version: bfee1239d796830ca346767650cce5ba90d58c57
 - name: gopkg.in/mattes/go-expand-tilde.v1
   version: cb884138e64c9a8bf5c7d6106d74b0fca082df0c
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,3 +25,8 @@ import:
 - package: gopkg.in/mattes/go-expand-tilde.v1
   version: cb884138e64c9a8bf5c7d6106d74b0fca082df0c
 - package: github.com/xeipuuv/gojsonschema
+- package: gopkg.in/gemnasium/logrus-airbrake-hook.v2
+  version: ~2.1.1
+- package: gopkg.in/airbrake/gobrake.v2
+  version: ~3.0.1
+- package: github.com/stretchr/objx


### PR DESCRIPTION
Added `go_import_path: github.com/akamai-open/AkamaiOPEN-edgegrid-golang` to ensure forked builds are successful.  Go import paths require strict directory structure.

Added 3 packages to glide config

Modified go test command to run `cd edgegrid && go test -v -race ./...` this includes testing for race conditions which is really useful if you are using channels or mutexes.